### PR TITLE
Produce signed release AAB and APK on tag

### DIFF
--- a/.github/workflows/createReleaseArtifacts.yml
+++ b/.github/workflows/createReleaseArtifacts.yml
@@ -24,21 +24,25 @@ jobs:
       - name: Decode keystore
         run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > "$RUNNER_TEMP/release.keystore"
 
-      - name: Build release bundle
+      - name: Build release artifacts
         env:
           KEYSTORE_FILE: ${{ runner.temp }}/release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew clean bundleRelease --stacktrace
+        run: ./gradlew clean assembleRelease bundleRelease --stacktrace
 
-      - name: Rename built artifact
-        run: mv app/build/outputs/bundle/release/app-release.aab app/build/outputs/bundle/release/SensorsManager_release_${{ github.ref_name }}.aab
+      - name: Rename built artifacts
+        run: |
+          mv app/build/outputs/apk/release/app-release.apk app/build/outputs/apk/release/SensorsManager_release_${{ github.ref_name }}.apk
+          mv app/build/outputs/bundle/release/app-release.aab app/build/outputs/bundle/release/SensorsManager_release_${{ github.ref_name }}.aab
 
-      - name: Export release bundle
+      - name: Export release artifacts
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: app/build/outputs/bundle/release/SensorsManager_release_${{ github.ref_name }}.aab
+          files: |
+            app/build/outputs/apk/release/SensorsManager_release_${{ github.ref_name }}.apk
+            app/build/outputs/bundle/release/SensorsManager_release_${{ github.ref_name }}.aab
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,10 +65,11 @@ cd iosApp && xcodegen generate       # generate iosApp.xcodeproj
   framework and the iOS app (via XcodeGen). Path-filtered to shared/iOS changes.
 - `.github/workflows/createDebugApk.yml` — builds and attaches a debug APK to a
   GitHub Release when a `*d` tag is pushed.
-- `.github/workflows/createReleaseAab.yml` — builds a signed release AAB (the
-  format Google Play requires) and attaches it to a GitHub Release when a tag is
-  pushed. Signing keystore and passwords come from the `KEYSTORE_BASE64`,
-  `KEYSTORE_PASSWORD`, `KEY_ALIAS` and `KEY_PASSWORD` repository secrets.
+- `.github/workflows/createReleaseArtifacts.yml` — builds a signed release AAB
+  (the format Google Play requires) and a signed release APK, and attaches both
+  to a GitHub Release when a tag is pushed. Signing keystore and passwords come
+  from the `KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_ALIAS` and `KEY_PASSWORD`
+  repository secrets.
 
 ## Conventions
 


### PR DESCRIPTION
Google Play requires an Android App Bundle for uploads, so the release pipeline now runs bundleRelease alongside assembleRelease and attaches both the signed .aab and .apk to the GitHub Release. The existing release signingConfig applies to both outputs, so no build.gradle change is needed.